### PR TITLE
CASMCMS-7676 Add support for templating IMS recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased]
-
-[1.0.0] - (no date)
+## [Unreleased]
+### Added
+- Add support for registering template variables when creating an IMS recipe

--- a/ims_python_helper/__init__.py
+++ b/ims_python_helper/__init__.py
@@ -359,7 +359,7 @@ class ImsHelper(object):
             ),
         }
 
-    def recipe_upload(self, name, filepath, distro, template_dictionary):
+    def recipe_upload(self, name, filepath, distro, template_dictionary=None):
         """
         Utility function that uploads a recipe to S3 and registers it with IMS.
         Only gzipped tar recipe archives are supported.
@@ -400,10 +400,16 @@ class ImsHelper(object):
                     LOGGER.error("Unable to delete recipe: %s", delete_err)
                     raise err
 
-        LOGGER.info(
-            "Starting recipe_upload; name=%s, file=%s, distro=%s, template_dictionary=%s",
-            name, filepath, distro, template_dictionary
-        )
+        if template_dictionary:
+            LOGGER.info(
+                "Starting recipe_upload; name=%s, file=%s, distro=%s, template_dictionary=%s",
+                name, filepath, distro, template_dictionary
+            )
+        else:
+            LOGGER.info(
+                "Starting recipe_upload; name=%s, file=%s, distro=%s",
+                name, filepath, distro
+            )
 
         # Get all recipes and filter for the current recipe
         recipes = self._ims_recipes_get()
@@ -483,18 +489,25 @@ class ImsHelper(object):
 
         if template_dictionary:
             template_dictionary = [{'key': k, 'value': v} for k, v in template_dictionary.items()]
-
-        LOGGER.info(
-            "POST %s name=%s, linux_distribution=%s, template_dictionary=%s",
-            name, url, linux_distribution, template_dictionary
-        )
+            LOGGER.info(
+                "POST %s name=%s, linux_distribution=%s, template_dictionary=%s",
+                name, url, linux_distribution, template_dictionary
+            )
+        else:
+            LOGGER.info(
+                "POST %s name=%s, linux_distribution=%s",
+                name, url, linux_distribution
+            )
 
         body = {
             'recipe_type': 'kiwi-ng',
             'linux_distribution': linux_distribution,
-            'template_dictionary': template_dictionary,
             'name': name,
         }
+
+        if template_dictionary:
+            body['template_dictionary'] = template_dictionary
+
         resp = self.session.post(url, json=body)
         resp.raise_for_status()
         return resp.json()

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -155,7 +155,6 @@ class TestImage(TestCase):
         exp_req_data = {
             'recipe_type': 'kiwi-ng',
             'linux_distribution': linux_distribution,
-            'template_dictionary': None,
             'name': recipe_name,
         }
         self.assertEqual(

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -21,25 +21,25 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
 """
 Unit tests for resources/images.py
 """
 
+import json
 import os
 import sys
-import json
-import mock
-import re
-import requests
-import responses
 import unittest
 import uuid
+
+import mock
+import requests
+import responses
 
 # Add ims_python_helper to path
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 
 from ims_python_helper import ImsHelper
-import fixtures
 from testtools import TestCase
 
 UPLOAD_TIMEOUT = 500
@@ -155,6 +155,38 @@ class TestImage(TestCase):
         exp_req_data = {
             'recipe_type': 'kiwi-ng',
             'linux_distribution': linux_distribution,
+            'template_dictionary': None,
+            'name': recipe_name,
+        }
+        self.assertEqual(
+            exp_req_data, json.loads(responses.calls[0].request.body))
+
+        self.assertEqual(fake_recipe_data, resp)
+
+    @responses.activate
+    def test_ims_recipe_create_with_template_dictionary(self):
+        """ Test _ims_recipe_create method when get a valid response from IMS. """
+
+        recipe_name = str(mock.sentinel.name)
+
+        fake_recipe_data = {'name': recipe_name}
+        responses.add(responses.POST, '{}/recipes'.format(self.ims_url),
+                      json=fake_recipe_data)
+
+        responses.add(
+            responses.GET, '{}/version'.format(self.ims_url), json={"version": "1.2.3"})
+
+        ims_helper = ImsHelper(self.ims_url, self.session)
+
+        linux_distribution = str(mock.sentinel.linux_distribution)
+        template_dictionary = {'CSM_VERSION': '1.0.0'}
+        resp = ims_helper._ims_recipe_create(
+            recipe_name, linux_distribution, template_dictionary)
+
+        exp_req_data = {
+            'recipe_type': 'kiwi-ng',
+            'linux_distribution': linux_distribution,
+            'template_dictionary': [{'key': k, 'value': v} for k, v in template_dictionary.items()],
             'name': recipe_name,
         }
         self.assertEqual(
@@ -168,7 +200,7 @@ class TestImage(TestCase):
 
         fake_error_data = {'title': 'Bad Request'}
         responses.add(responses.POST, '{}/recipes'.format(self.ims_url),
-            json=fake_error_data, status=400)
+                      json=fake_error_data, status=400)
         responses.add(
             responses.GET, '{}/version'.format(self.ims_url), json={"version": "1.2.3"})
 


### PR DESCRIPTION
Note: A previous PR was approved however it had to be closed due to renaming of the source branch. 

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Update ims-python-helper for adding recipes to IMS with template variables.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-7676](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7676)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Created a test recipe helm chart based on the updated cray-product-install-chart and ims-load-artifacts container. Installed this test recipe helm chart on mug. Saw that the recipe was added to IMS as expected, including that all templating during the helm install occurred as expected. Verified that building the recipe using IMS templated the recipe as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? No
- Was upgrade tested? If not, why? yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

