### PR TITLE
Feature/casmcms 7970

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 [Unreleased]
+### Changed
+- CASMCMS-7970 - update dev.cray.com server addresses.
 
 [1.0.0] - (no date)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # Only use Cray-procured packages
---index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple
 -c constraints.txt
 -e .


### PR DESCRIPTION
## Summary and Scope

Remove the internal python repo for pip installs.

## Issues and Related PRs
* Resolves [CASMCMS-7970](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7970)

## Testing
### Tested on:
  * Build system

### Test description:

This change will be tested as it is integrated with other services that use it.

## Risks and Mitigations

Pulling the same python packages, just from a different repo - minimal risk.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated

