### PR TITLE
CASMINST-5443: Add authentication warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Install the package via pip with the Cray internal pip index url:
 ```bash
 pip install ims-python-helper --trusted-host artifactory.algol60.net --index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
 ```
+NOTE: This may require you to authenticate to artifactory.
 
 ### Assumptions
 


### PR DESCRIPTION
## Summary and Scope

Artifactory requires authentication, so to do an installation from it will require the caller to authenticate.## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-5443

## Testing


### Tested on:

Didn't.

### Test description:

I added a warning about needing to authenticate. Nothing to test.

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

