### PR TITLE
Release/2.10.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence, the
 # owners listed in this stanza will be requested for review
 # when someone opens a pull request.
-*       @Cray-HPE/CMS-core-ims
+*	@Cray-HPE/Cray-Management-Systems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.10.1] - 2022-12-02
 ### Added
 - Add a note in the README about authenticating to CSM's artifactory.
 


### PR DESCRIPTION
## Summary and Scope

Put in a note saying you need to authenticate to CSM's artifactory when using pip to access CSM's csm-python-modules.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-5443

## Testing


### Tested on:

  * Tested by committing it to the build environment. There was not an artifactory available with the correct permissions to test against.

### Test description:

See above.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No.
- Were continuous integration tests run? If not, why? No.
- Was upgrade tested? If not, why? No.
- Was downgrade tested? If not, why? No.
- Were new tests (or test issues/Jiras) created for this change? No.

## Risks and Mitigations
Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

