### PR TITLE
CASM-3760: Skip images that are already uploaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.11.0] - 2023-01-17
-- Change `ImsHelper.image_upload_artifacts()` to skip uploading an image
-  for which there is already an image with a matching name in IMS which has
-  associated artifacts.
+### Changed
+- Change `ImsHelper.image_upload_artifacts()` to add an option to skip 
+  uploading an image for which there is already an image with a matching 
+  name in IMS which has associated artifacts.
 
 ## [2.10.2] - 2022-12-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.0] - 2023-01-17
+- Change `ImsHelper.image_upload_artifacts()` to skip uploading an image
+  for which there is already an image with a matching name in IMS which has
+  associated artifacts.
+
 ## [2.10.2] - 2022-12-20
 ### Added
 - Add Artifactory authentication to Jenkinsfile

--- a/ims_python_helper/__init__.py
+++ b/ims_python_helper/__init__.py
@@ -59,6 +59,16 @@ DEFAULT_IMS_API_URL = 'https://api-gw-service-nmn.local/apis/ims'
 class ImsImageAlreadyUploaded(Exception):
     """A populated image with some given name already exists in IMS."""
 
+    def __init__(self, image_record: Dict, *args):
+        super().__init__(*args)
+        self.image_record = image_record
+
+    def __str__(self):
+        return "image with name \"{}\" already exists in IMS (ID: {})".format(
+            self.image_record.get("name"),
+            self.image_record.get("id"),
+        )
+
 
 class ImsHelper(object):
     """
@@ -250,16 +260,20 @@ class ImsHelper(object):
         resp.raise_for_status()
         return resp
 
-    def get_empty_image_record_for_name(self, image_name: str) -> Dict:
+    def get_empty_image_record_for_name(self, image_name: str, skip_existing: bool) -> Dict:
         """Get an empty record for an image in IMS with the given name.
 
         If an image with the given name does not exist, an empty image
         record will be created. If an empty image record exists, it will
         be returned. If an uploaded image record exists, then
-        ImsImageAlreadyUploaded will be raised.
+        ImsImageAlreadyUploaded will be raised with the given image record
+        if `skip_existing` is True, and a new image will be created and
+        returned if `skip_existing` is False.
 
         Args:
             image_name: the desired name of the image
+            skip_existing: if True, check if an image exists with the name
+                `image_name`. If it exists, check if it has a `link` attribute
 
         Returns:
             dict: the empty IMS image record for the image, containing e.g.
@@ -267,27 +281,28 @@ class ImsHelper(object):
 
         Raises:
             ImsImageAlreadyUploaded: if the image already exists and
-                has been uploaded
+                has been uploaded, and `skip_existing` is True
         """
-        try:
-            existing_images = self._ims_images_get()
-            for image in existing_images:
-                if image.get("name") == image_name:
-                    if image.get("link"):
-                        raise ImsImageAlreadyUploaded(image_name)
-                    else:
-                        LOGGER.info("Image \"%s\" with ID \"%s\" found, but it has not been "
-                                    "uploaded yet; uploading now.", image_name, image.get("id"))
-                        return image
-        except requests.HTTPError as err:
-            LOGGER.warning("Could not retrieve existing images: %s", err)
+        if skip_existing:
+            try:
+                existing_images = self._ims_images_get()
+                for image in existing_images:
+                    if image.get("name") == image_name:
+                        if image.get("link"):
+                            raise ImsImageAlreadyUploaded(image)
+                        else:
+                            LOGGER.info("Image \"%s\" with ID \"%s\" found, but it has not been "
+                                        "uploaded yet.", image_name, image.get("id"))
+                            return image
+            except requests.HTTPError as err:
+                LOGGER.warning("Could not retrieve existing images: %s", err)
 
-        LOGGER.info("No image found in IMS with name \"%s\"; creating.", image_name)
+        LOGGER.info("Creating image with name \"%s\"", image_name)
         return self._ims_image_create(image_name)
 
     def image_upload_artifacts(
             self, image_name, ims_job_id=None, rootfs=None, kernel=None,
-            initrd=None, debug=None, boot_parameters=None
+            initrd=None, debug=None, boot_parameters=None, skip_existing=False,
     ):
         """
         Utility function to upload and register any image artifacts with the
@@ -295,8 +310,9 @@ class ImsHelper(object):
         values are expected to be full paths to readable files. Only squashfs
         is currently supported for the rootfs parameter.
 
-        If an image with name `image_name` and a `link` attribute already
-        exists in IMS, then this function will return without uploading anything.
+        If `skip_existing` is True and an image with name `image_name` and a
+        `link` attribute already exists in IMS, then this function will return
+        the existing image record without uploading anything.
         """
 
         # Stub out the return value of this method
@@ -306,10 +322,10 @@ class ImsHelper(object):
         }
 
         try:
-            image_record = self.get_empty_image_record_for_name(image_name)
-        except ImsImageAlreadyUploaded:
+            image_record = self.get_empty_image_record_for_name(image_name, skip_existing)
+        except ImsImageAlreadyUploaded as exc:
             LOGGER.warning("Image with name %s already exists in IMS; skipping.", image_name)
-            return
+            return exc.image_record
 
         ret["ims_image_record"] = image_record
         image_id = ret["ims_image_record"]["id"]

--- a/ims_python_helper/__init__.py
+++ b/ims_python_helper/__init__.py
@@ -255,14 +255,15 @@ class ImsHelper(object):
 
         If an image with the given name does not exist, and empty image
         record will be created. If an empty image record exists, it will
-        be returned. If an uploaded image record exists, then ImsImageExists
-        will be raised.
+        be returned. If an uploaded image record exists, then
+        ImsImageAlreadyUploaded will be raised.
 
         Args:
             image_name: the desired name of the image
 
         Raises:
-            ImsImageExists: if the image already exists and has been uploaded
+            ImsImageAlreadyUploaded: if the image already exists and
+                has been uploaded
 
         Returns:
             dict: the empty IMS image record for the image, containing e.g.

--- a/ims_python_helper/__init__.py
+++ b/ims_python_helper/__init__.py
@@ -32,7 +32,7 @@ from datetime import datetime
 
 import sys
 from time import sleep
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from pkg_resources import get_distribution
 

--- a/ims_python_helper/__init__.py
+++ b/ims_python_helper/__init__.py
@@ -253,7 +253,7 @@ class ImsHelper(object):
     def get_empty_image_record_for_name(self, image_name: str) -> Dict:
         """Get an empty record for an image in IMS with the given name.
 
-        If an image with the given name does not exist, and empty image
+        If an image with the given name does not exist, an empty image
         record will be created. If an empty image record exists, it will
         be returned. If an uploaded image record exists, then
         ImsImageAlreadyUploaded will be raised.
@@ -261,13 +261,13 @@ class ImsHelper(object):
         Args:
             image_name: the desired name of the image
 
-        Raises:
-            ImsImageAlreadyUploaded: if the image already exists and
-                has been uploaded
-
         Returns:
             dict: the empty IMS image record for the image, containing e.g.
                 the name, the id, and the creation timestamp
+
+        Raises:
+            ImsImageAlreadyUploaded: if the image already exists and
+                has been uploaded
         """
         try:
             existing_images = self._ims_images_get()

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -137,7 +137,7 @@ class TestImage(TestCase):
             responses.GET, f'{self.ims_url}/images', json=self.existing_ims_images
         )
         responses.add(responses.POST, f'{self.ims_url}/images', status=201, json=self.new_ims_image)
-        result = ImsHelper(self.ims_url, self.session).get_empty_image_record_for_name('newly_created_image')
+        result = ImsHelper(self.ims_url, self.session).get_empty_image_record_for_name('newly_created_image', skip_existing=True)
         assert result == self.new_ims_image
 
     @responses.activate
@@ -147,7 +147,7 @@ class TestImage(TestCase):
             responses.GET, f'{self.ims_url}/images', json=self.existing_ims_images
         )
         responses.add(responses.POST, f'{self.ims_url}/images', status=201)
-        result = ImsHelper(self.ims_url, self.session).get_empty_image_record_for_name('image_created_but_not_uploaded')
+        result = ImsHelper(self.ims_url, self.session).get_empty_image_record_for_name('image_created_but_not_uploaded', skip_existing=True)
         assert result == self.existing_ims_images[1]
 
     @responses.activate
@@ -159,7 +159,7 @@ class TestImage(TestCase):
         responses.add(responses.POST, f'{self.ims_url}/images', status=201)
 
         def should_raise():
-            ImsHelper(self.ims_url, self.session).get_empty_image_record_for_name('image_that_has_been_uploaded')
+            ImsHelper(self.ims_url, self.session).get_empty_image_record_for_name('image_that_has_been_uploaded', skip_existing=True)
 
         self.assertRaises(ImsImageAlreadyUploaded, should_raise)
 


### PR DESCRIPTION
## Summary and Scope

This change modifies the behavior of the
`ImsHelper.image_upload_artifacts()` method to skip uploading images
which have already been uploaded. The method now checks if there is an
image in IMS which has the same name as the desired image, and if it has
associated artifacts, then it is skipped. Empty images are uploaded and
patched.

## Issues and Related PRs

* Resolves [CASM-3760](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3760)

## Testing


### Tested on:

  * `mug`


### Test description:

Test on internal system by uploading artifacts to empty images, creating
new images, and attempting to re-upload existing images using a test
harness script.

Run unit tests.

Test output here: https://gist.github.com/jack-stanek-hpe/ed2c8cd22ec5892c69162bc96d6fbb74

## Risks and Mitigations

Newer version can be contained to use only with IUF version of `ims-load-artifacts` for now.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

