### PR TITLE
CASMINST-5926: Fix KeyError on `"ims_image_record"` in return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1] - 2023-02-06
+### Fixed
+- Fix bug where an `"ims_image_record"` key was not being returned in
+  the dict returned by `ImsHelper.image_upload_artifacts()`.
+
 ## [2.11.0] - 2023-01-17
 ### Changed
-- Change `ImsHelper.image_upload_artifacts()` to add an option to skip 
-  uploading an image for which there is already an image with a matching 
+- Change `ImsHelper.image_upload_artifacts()` to add an option to skip
+  uploading an image for which there is already an image with a matching
   name in IMS which has associated artifacts.
 
 ## [2.10.2] - 2022-12-20

--- a/ims_python_helper/__init__.py
+++ b/ims_python_helper/__init__.py
@@ -325,7 +325,8 @@ class ImsHelper(object):
             image_record = self.get_empty_image_record_for_name(image_name, skip_existing)
         except ImsImageAlreadyUploaded as exc:
             LOGGER.warning("Image with name %s already exists in IMS; skipping.", image_name)
-            return exc.image_record
+            ret['ims_image_record'] = exc.image_record
+            return ret
 
         ret["ims_image_record"] = image_record
         image_id = ret["ims_image_record"]["id"]
@@ -344,6 +345,9 @@ class ImsHelper(object):
         if boot_parameters:
             to_upload.append(('application/vnd.cray.image.parameters.boot', key % 'boot_parameters',
                               boot_parameters[0]))  # noqa: E501
+        if not to_upload:
+            LOGGER.info("No image artifacts supplied for image %s; not uploading anything.", image_name)
+            return ret
 
         # Upload the files in series
         LOGGER.info(

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -150,6 +150,14 @@ class TestImage(TestCase):
         result = ImsHelper(self.ims_url, self.session).get_empty_image_record_for_name('image_created_but_not_uploaded', skip_existing=True)
         assert result == self.existing_ims_images[1]
 
+    def test_get_existing_image_record(self):
+        """Test that an "ims_image_record" key is returned by image_upload_artifacts()"""
+        image_record = self.existing_ims_images[0]
+        with mock.patch('ims_python_helper.ImsHelper.get_empty_image_record_for_name',
+                        side_effect=ImsImageAlreadyUploaded(image_record)):
+            result = ImsHelper(self.ims_url, self.session).image_upload_artifacts('image_that_has_been_uploaded')
+            self.assertEqual(result['ims_image_record'], self.existing_ims_images[0])
+
     @responses.activate
     def test_get_empty_image_record_for_existing_uploaded_image(self):
         """Test images are not uploaded when a populated image of the same name already exists in IMS."""


### PR DESCRIPTION
## Summary and Scope


This change resolves a KeyError in the `ims-load-artifacts` container
image in the IUF `ims-upload` operation. When an image already exists in
IMS with the same name, the image record was being returned directly
instead of as a key in the return dictionary.

## Issues and Related PRs

* Resolves [CASMINST-5926](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5926)

## Testing

### Tested on:

  * Local development environment

### Test description:

Run unit tests. Check out `ims_python_helper/__init__.py` from develop branch and run tests against that, ensure they fail.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

