### PR TITLE
CASMINST-6081: Use md5sum to check if recipe matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.12.0] - 2023-03-27
 ### Changed
 - Changed the behavior of `ImsHelper.recipe_upload()` to only skip uploading a
-  recipe if the artifact MD5 sums match, not just of the IMS image names match.
+  recipe if the artifact MD5 sums match, not just if the IMS image names match.
 
 
 ## [2.11.1] - 2023-02-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.0] - 2023-03-27
+### Changed
+- Changed the behavior of `ImsHelper.recipe_upload()` to only skip uploading a
+  recipe if the artifact MD5 sums match, not just of the IMS image names match.
+
+
 ## [2.11.1] - 2023-02-06
 ### Fixed
 - Fix bug where an `"ims_image_record"` key was not being returned in


### PR DESCRIPTION


## Summary and Scope
This change checks the MD5 checksum of an image tarball against the `md5sum` metadata recorded in S3 for a given recipe artifact to determine if a given image has already been uploaded to IMS.

## Issues and Related PRs

* Resolves [CASMINST-6081](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6081)

## Testing

### Tested on:

  * `rocket`

### Test description:

Test manually with a test harness script by uploading the same recipe multiple times, and then checking with recipes with different contents, and with recipes with the same name but empty links.

See testing here: https://gist.github.com/jack-stanek-hpe/e8f01617d29a6a588156a2e2cca49b35


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

