### PR TITLE
CASMCMS-8821 - changes for remote customize jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- CASMCMS-8821 - add argument to disable unsquashing downloaded image file.
 
 ## [2.15.0] - 2023-09-26
 ### Added

--- a/ims_python_helper/fetch.py
+++ b/ims_python_helper/fetch.py
@@ -289,7 +289,7 @@ class FetchImage(FetchBase):
             self.ims_helper.image_set_job_status(self.IMS_JOB_ID, "error")
             sys.exit(1)
 
-    def run(self):
+    def run(self, unpack: bool = True):
         try:
             LOGGER.info("Setting job status to 'fetching_image'.")
             self.ims_helper.image_set_job_status(self.IMS_JOB_ID, "fetching_image")
@@ -299,14 +299,17 @@ class FetchImage(FetchBase):
             self.download_file(self.url, self.image_sqshfs)
             LOGGER.info("Deleting signal files")
             self.delete_signal_files()
-            LOGGER.info("Uncompressing image into %s", self.path)
-            self.unsquash_image()
+            if unpack:
+                LOGGER.info("Uncompressing image into %s", self.path)
+                self.unsquash_image()
+            else:
+                LOGGER.info("Skipping image unsquash")
         except Exception as exc:
             LOGGER.error("Error unhandled exception while fetching image root.", exc_info=exc)
             self.ims_helper.image_set_job_status(self.IMS_JOB_ID, "error")
             sys.exit(1)
         finally:
-            if os.path.isfile(self.image_sqshfs):
+            if os.path.isfile(self.image_sqshfs) and unpack:
                 LOGGER.info("Deleting compressed image %s", self.image_sqshfs)
                 os.remove(self.image_sqshfs)
             LOGGER.info("Done")


### PR DESCRIPTION
## Summary and Scope

Give an option for FetchImage to unpack the fetched squashfs file or not. The remote job path does not need the image automatically unpacked in the k8s job pod.

## Issues and Related PRs
* Resolves [CASMCMS-8821 ](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8821)

## Testing
### Tested on:
  * `Mug`, `Tyr`, `Baldar`

### Test description:

3 Months of soak-testing

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

