### PR TITLE
CASMCMS-9142: Fix Python-related build failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- CASMCMS-9142: Install Python modules with `--user` to avoid build failures, and build inside Docker container.
+
 ## [3.1.0] - 2024-06-10
 ### Dependencies
 Bumped dependency patch versions:

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -25,6 +25,8 @@
  */
 @Library('cms-meta-tools') _
 @Library('csm-shared-library') __
+
+def pyImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python'
 
 pipeline {
     agent {
@@ -72,20 +74,17 @@ pipeline {
             }
         }
 
-        stage("Install necessary tools") {
+        stage("Build Python Module") {
+            agent {
+                docker {
+                    args "-v /home/jenkins/.ssh:/home/jenkins/.ssh -v /home/jenkins/.netrc:/home/jenkins/.netrc"
+                    reuseNode true
+                    image "${pyImage}:3.11"
+                }
+            }
             steps {
                 sh "make prepare"
-            }
-        }
-
-        stage("Build Python Module") {
-            steps {
                 sh "make python_wheel"
-            }
-        }
-
-        stage('Unit Tests') {
-            steps {
                 sh "make unit_test"
             }
         }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -35,8 +35,8 @@ lint:
 		./cms_meta_tools/scripts/runLint.sh
 
 prepare:
-		pip3 install --upgrade pip setuptools
-		pip3 install wheel
+		pip3 install --upgrade --user pip setuptools
+		pip3 install --user wheel
 
 		rm -rf dist
 		mkdir -p $(BUILD_DIR)/SPECS $(BUILD_DIR)/SOURCES
@@ -45,8 +45,8 @@ python_wheel:
 		python3 setup.py sdist bdist_wheel
 
 unit_test:
-		pip3 install -r requirements.txt
-		pip3 install -r requirements-test.txt
+		pip3 install --user -r requirements.txt
+		pip3 install --user -r requirements-test.txt
 		python3 tests/test_images.py
 		pycodestyle --config=.pycodestyle ./ims_python_helper || true
 		pylint ./ims_python_helper || true


### PR DESCRIPTION
A change on the Jenkins builders has broken how this repo builds its Python module. This PR fixes it by moving that build into a Docker container and installing Python modules using `--user`.