### PR TITLE
CASMCMS-9510: Change logging level based on environment variable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- CASMCMS-9510: Change logging level for `ims-python-helper` based on environment variable.
+
 ## [3.2.0] - 2024-09-19
 
 ### Dependencies

--- a/ims_python_helper/__main__.py
+++ b/ims_python_helper/__main__.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2018-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2018-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -312,7 +312,10 @@ def main(program_name, args):
 
     parser = create_parser(program_name)
     args = parser.parse_args(args)
-    logging.basicConfig(level=args.log_level)
+    log_level = args.log_level if 'log_level' in args and args.log_level != parser.get_default('log_level') \
+        else os.environ.get('LOG_LEVEL', 'INFO')
+
+    logging.basicConfig(level=log_level)
 
     ims_helper_kwargs = {
         'ims_url': args.ims_url,


### PR DESCRIPTION
## Summary and Scope

CASMCMS-9510: Change logging level based on environment variable.

The change adds the flexibility to the users to change logging level during `build image` and `customize image`. 

## Testing
This was tested on `mug`. Following tests were run for `build image` and `customize image`
> `LOG_LEVEL` ENV set to `INFO` 
> `LOG_LEVEL` ENV set to `WARNING`
> `LOG_LEVEL` ENV set to `DEBUG`
> Remove `LOG_LEVEL` ENV variable  from build image` and `customize image` configmap.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

