### PR TITLE
CASMCMS-9596 - pin version of testtools to fix api change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Dependencies
+- CASMCMS-9596 - pin 'testtools' to <2.8 to avoid build issues.
 
 ## [3.3.0] - 2025-08-19
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -9,4 +9,5 @@ requests==2.32.4
 requests-oauthlib==2.0.0
 s3transfer==0.11.3 # botocore 1.36.2 requires 0.11.3
 six==1.17.0 # botocore 1.36.2 requires 1.17.0
+testtools>=2.7,<2.8
 urllib3==2.4.0


### PR DESCRIPTION
## Summary and Scope

Version 2.8.0 of the python module 'testtools' has a breaking API change. This just pins the version to use 2.7.x so the automatic nightly rebuilds will succeed for inclusion of new CVE fixes.

## Issues and Related PRs
* Resolves [CASMCMS-9596](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9596)

## Testing

None - this only impacts the unit tests, so no real system testing is required.

## Risks and Mitigations

If this is not picked up, the automatic rebuilds will fail.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable